### PR TITLE
When values are set, pass them to overriders

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -131,10 +131,10 @@ type DecoderConfigOption func(*mapstructure.DecoderConfig)
 // DecodeHook returns a DecoderConfigOption which overrides the default
 // DecoderConfig.DecodeHook value, the default is:
 //
-//  mapstructure.ComposeDecodeHookFunc(
-//		mapstructure.StringToTimeDurationHookFunc(),
-//		mapstructure.StringToSliceHookFunc(","),
-//	)
+//	 mapstructure.ComposeDecodeHookFunc(
+//			mapstructure.StringToTimeDurationHookFunc(),
+//			mapstructure.StringToSliceHookFunc(","),
+//		)
 func DecodeHook(hook mapstructure.DecodeHookFunc) DecoderConfigOption {
 	return func(c *mapstructure.DecoderConfig) {
 		c.DecodeHook = hook
@@ -155,18 +155,18 @@ func DecodeHook(hook mapstructure.DecodeHookFunc) DecoderConfigOption {
 //
 // For example, if values from the following sources were loaded:
 //
-//  Defaults : {
-//  	"secret": "",
-//  	"user": "default",
-//  	"endpoint": "https://localhost"
-//  }
-//  Config : {
-//  	"user": "root"
-//  	"secret": "defaultsecret"
-//  }
-//  Env : {
-//  	"secret": "somesecretkey"
-//  }
+//	Defaults : {
+//		"secret": "",
+//		"user": "default",
+//		"endpoint": "https://localhost"
+//	}
+//	Config : {
+//		"user": "root"
+//		"secret": "defaultsecret"
+//	}
+//	Env : {
+//		"secret": "somesecretkey"
+//	}
 //
 // The resulting config will have the following values:
 //
@@ -230,6 +230,7 @@ type Viper struct {
 // If Get() returns nil, the override is discarded and parameter search continues
 type Overrider interface {
 	Get(lowerCaseKey string) interface{}
+	Set(lowerCaseKey string, value interface{})
 }
 
 // New returns an initialized Viper instance.
@@ -794,7 +795,8 @@ func (v *Viper) searchMapWithPathPrefixes(
 // isPathShadowedInDeepMap makes sure the given path is not shadowed somewhere
 // on its path in the map.
 // e.g., if "foo.bar" has a value in the given map, it “shadows”
-//       "foo.bar.baz" in a lower-priority map
+//
+//	"foo.bar.baz" in a lower-priority map
 func (v *Viper) isPathShadowedInDeepMap(path []string, m map[string]interface{}) string {
 	var parentVal interface{}
 	for i := 1; i < len(path); i++ {
@@ -819,7 +821,8 @@ func (v *Viper) isPathShadowedInDeepMap(path []string, m map[string]interface{})
 // isPathShadowedInFlatMap makes sure the given path is not shadowed somewhere
 // in a sub-path of the map.
 // e.g., if "foo.bar" has a value in the given map, it “shadows”
-//       "foo.bar.baz" in a lower-priority map
+//
+//	"foo.bar.baz" in a lower-priority map
 func (v *Viper) isPathShadowedInFlatMap(path []string, mi interface{}) string {
 	// unify input map
 	var m map[string]interface{}
@@ -844,7 +847,8 @@ func (v *Viper) isPathShadowedInFlatMap(path []string, mi interface{}) string {
 // isPathShadowedInAutoEnv makes sure the given path is not shadowed somewhere
 // in the environment, when automatic env is on.
 // e.g., if "foo.bar" has a value in the environment, it “shadows”
-//       "foo.bar.baz" in a lower-priority map
+//
+//	"foo.bar.baz" in a lower-priority map
 func (v *Viper) isPathShadowedInAutoEnv(path []string) string {
 	var parentKey string
 	for i := 1; i < len(path); i++ {
@@ -865,11 +869,11 @@ func (v *Viper) isPathShadowedInAutoEnv(path []string) string {
 // would return a string slice for the key if the key's type is inferred by
 // the default value and the Get function would return:
 //
-//   []string {"a", "b", "c"}
+//	[]string {"a", "b", "c"}
 //
 // Otherwise the Get function would return:
 //
-//   "a b c"
+//	"a b c"
 func SetTypeByDefaultValue(enable bool) { v.SetTypeByDefaultValue(enable) }
 
 func (v *Viper) SetTypeByDefaultValue(enable bool) {
@@ -1150,9 +1154,8 @@ func (v *Viper) BindPFlags(flags *pflag.FlagSet) error {
 // BindPFlag binds a specific key to a pflag (as used by cobra).
 // Example (where serverCmd is a Cobra instance):
 //
-//	 serverCmd.Flags().Int("port", 1138, "Port to run Application server on")
-//	 Viper.BindPFlag("port", serverCmd.Flags().Lookup("port"))
-//
+//	serverCmd.Flags().Int("port", 1138, "Port to run Application server on")
+//	Viper.BindPFlag("port", serverCmd.Flags().Lookup("port"))
 func BindPFlag(key string, flag *pflag.Flag) error { return v.BindPFlag(key, flag) }
 
 func (v *Viper) BindPFlag(key string, flag *pflag.Flag) error {
@@ -1561,6 +1564,12 @@ func (v *Viper) Set(key string, value interface{}) {
 
 	// set innermost value
 	deepestMap[lastKey] = value
+
+	// Give each overrider the value, so they can take whatever action
+	// they need to, like updating their external state
+	for _, o := range v.overriders {
+		o.Set(key, value)
+	}
 }
 
 // ReadInConfig will discover and load the configuration file from disk
@@ -2026,9 +2035,10 @@ func (v *Viper) AllKeys() []string {
 
 // flattenAndMergeMap recursively flattens the given map into a map[string]bool
 // of key paths (used as a set, easier to manipulate than a []string):
-// - each path is merged into a single key string, delimited with v.keyDelim
-// - if a path is shadowed by an earlier value in the initial shadow map,
-//   it is skipped.
+//   - each path is merged into a single key string, delimited with v.keyDelim
+//   - if a path is shadowed by an earlier value in the initial shadow map,
+//     it is skipped.
+//
 // The resulting set of paths is merged to the given shadow set at the same time.
 func (v *Viper) flattenAndMergeMap(shadow map[string]bool, m map[string]interface{}, prefix string) map[string]bool {
 	if shadow != nil && prefix != "" && shadow[prefix] {

--- a/viper_test.go
+++ b/viper_test.go
@@ -2286,6 +2286,10 @@ type overrider struct {
 	Val interface{}
 }
 
+func (o *overrider) Set(lowerCaseKey string, value interface{}) {
+
+}
+
 func (o *overrider) Get(key string) interface{} {
 	if o.Key == key {
 		return o.Val
@@ -2353,6 +2357,21 @@ func TestOverridersInts(t *testing.T) {
 
 	// Verify GetInt() returns int
 	assert.Equal(t, value, GetInt(key))
+}
+
+func TestOverridersSet(t *testing.T) {
+	Reset()
+
+	key := "key"
+	o := &overrider{
+		Key: key,
+	}
+	AddOverrider(o)
+
+	expectedValue := "some new value"
+	Set(key, expectedValue)
+
+	assert.Equal(t, expectedValue, Get(key))
 }
 
 func TestOverridersStrings(t *testing.T) {

--- a/viper_test.go
+++ b/viper_test.go
@@ -2287,7 +2287,6 @@ type overrider struct {
 }
 
 func (o *overrider) Set(lowerCaseKey string, value interface{}) {
-
 }
 
 func (o *overrider) Get(key string) interface{} {


### PR DESCRIPTION
Each overrider can determine what is necessary to represent its state when a value is set